### PR TITLE
fix: pass the target commit to cr upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,11 @@ npx hevi release <directory> \
 | `--owner`  | string | inferred   | GitHub user or organization.                                      |
 | `--repo`   | string | inferred   | GitHub repository name.                                           |
 | `--branch` | string | `gh-pages` | Branch the charts and `index.yaml` are published to.               |
+| `--commit` | string | `GITHUB_SHA` | Commit the created releases point to. Required outside of GitHub Actions. |
 | `--token`  | string | inferred   | Git token.                                                        |
 | `--generateReleaseNotes` | boolean | `false` | Let GitHub generate the release name and body from merged pull requests. |
 
-Inside GitHub Actions, `--owner`, `--repo` and `--token` are read from the environment
+Inside GitHub Actions, `--owner`, `--repo`, `--commit` and `--token` are read from the environment
 (see [Environment](#environment)), so they can usually be omitted. Existing releases are
 skipped, making re-runs safe.
 
@@ -188,6 +189,7 @@ versionize, package, release, push.
 | `release-owner`  | inferred       | GitHub owner.                                                      |
 | `release-repo`   | inferred       | GitHub repository name.                                            |
 | `release-branch` | `gh-pages`     | Branch the charts and `index.yaml` are published to.               |
+| `release-commit` | `github.sha`   | Commit the created releases point to.                              |
 | `release-generate-notes` | `false` | Let GitHub generate the release name and body.               |
 | `token`          | `github.token` | Token used to interact with GitHub.                                |
 | `push`           | `false`        | Push the packaged charts to an OCI registry.                       |
@@ -348,6 +350,7 @@ A `.env` file is loaded automatically by the CLI.
 | `GITHUB_TOKEN`      | `release` | Git token; preferred over `GH_TOKEN`.                            |
 | `GH_TOKEN`          | `release` | Fallback git token.                                              |
 | `GITHUB_REPOSITORY` | `release` | Source of `owner`/`repo` when they are not passed explicitly.    |
+| `GITHUB_SHA`        | `release` | Source of `commit` when it is not passed explicitly.             |
 | `RUNNER_TOOL_CACHE` | all       | Cache directory for downloaded binaries; defaults to the temp dir.|
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
         description: 'Branch the charts and index.yaml are published to.'
         required: false
         default: 'gh-pages'
+    release-commit:
+        description: 'Commit the created GitHub releases point to. Defaults to the commit that triggered the workflow.'
+        required: false
+        default: ${{ github.sha }}
     release-generate-notes:
         description: 'Let GitHub generate the release name and body from merged pull requests. Only relevant when chart-releaser owns the release creation.'
         required: false
@@ -118,6 +122,7 @@ runs:
               if [ -n "${{ inputs['release-owner'] }}" ]; then args="$args --owner ${{ inputs['release-owner'] }}"; fi
               if [ -n "${{ inputs['release-repo'] }}" ]; then args="$args --repo ${{ inputs['release-repo'] }}"; fi
               if [ -n "${{ inputs['release-branch'] }}" ]; then args="$args --branch ${{ inputs['release-branch'] }}"; fi
+              if [ -n "${{ inputs['release-commit'] }}" ]; then args="$args --commit ${{ inputs['release-commit'] }}"; fi
               if [ "${{ inputs['release-generate-notes'] }}" = "true" ]; then args="$args --generateReleaseNotes"; fi
 
               node "${{ github.action_path }}/dist/cli.mjs" release "${{ inputs.directory }}" $args

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -35,6 +35,10 @@ export function defineCLIReleaseCommand() {
                 type: 'string',
                 description: 'Github pages branch',
             },
+            commit: {
+                type: 'string',
+                description: 'Target commit for the release (default: GITHUB_SHA)',
+            },
             token: {
                 type: 'string',
                 description: 'Git token',
@@ -55,6 +59,7 @@ export function defineCLIReleaseCommand() {
                     owner: ctx.args.owner,
                     token: ctx.args.token,
                     branch: ctx.args.branch,
+                    commit: ctx.args.commit,
                     generateReleaseNotes: ctx.args.generateReleaseNotes,
                 });
 

--- a/src/helm/chart/helpers/push/normalize.ts
+++ b/src/helm/chart/helpers/push/normalize.ts
@@ -17,6 +17,7 @@ export function normalizeHelmChartsReleaseOptions(input: HelmChartsReleaseOption
         owner: input.owner,
         repo: input.repo,
         branch: input.branch,
+        commit: input.commit,
         token: input.token,
         generateReleaseNotes: input.generateReleaseNotes ?? false,
     };
@@ -26,6 +27,10 @@ export function normalizeHelmChartsReleaseOptions(input: HelmChartsReleaseOption
          */
     if (!options.branch) {
         options.branch = 'gh-pages';
+    }
+
+    if (!options.commit) {
+        options.commit = process.env.GITHUB_SHA || undefined;
     }
 
     if (!options.token) {

--- a/src/helm/chart/helpers/push/types.ts
+++ b/src/helm/chart/helpers/push/types.ts
@@ -27,6 +27,16 @@ export type HelmChartsReleaseOptions = {
     branch?: string,
 
     /**
+     * Commit the created GitHub release points to (target_commitish).
+     *
+     * chart-releaser forwards this value unchecked, and the GitHub API rejects
+     * an empty one, so it must resolve to something.
+     *
+     * default: GITHUB_SHA
+     */
+    commit?: string,
+
+    /**
      * Let GitHub generate the name and body of the release from the merged
      * pull requests, instead of falling back to the chart description.
      *
@@ -58,6 +68,11 @@ export type HelmChartsReleaseOptionsNormalized = {
      * branch to upload charts + index file
      */
     branch?: string,
+
+    /**
+     * Commit the created GitHub release points to (target_commitish).
+     */
+    commit?: string,
 
     /**
      * Let GitHub generate the name and body of the release.

--- a/src/helm/chart/manager.ts
+++ b/src/helm/chart/manager.ts
@@ -234,10 +234,17 @@ export class HelmChartManager implements IHelmChartManager {
             uploadArgs.push('--pages-branch', options.branch);
         }
 
-        // --generate-release-notes is only accepted by upload, not by index
+        // --generate-release-notes and --commit are only accepted by upload, not by
+        // index (where the -c shorthand means --charts-repo)
         const uploadOnlyArgs : string[] = [];
         if (options.generateReleaseNotes) {
             uploadOnlyArgs.push('--generate-release-notes');
+        }
+
+        // chart-releaser forwards this as the release's target_commitish without a
+        // default, and GitHub answers 422 for an empty one
+        if (options.commit) {
+            uploadOnlyArgs.push('--commit', options.commit);
         }
 
         // release step

--- a/test/unit/helm/chart/helpers.spec.ts
+++ b/test/unit/helm/chart/helpers.spec.ts
@@ -22,6 +22,7 @@ const ENV_KEYS = [
     'GH_TOKEN',
     'GITHUB_REF',
     'GITHUB_REPOSITORY',
+    'GITHUB_SHA',
 ] as const;
 
 describe('helm > chart > helpers > version', () => {
@@ -66,6 +67,7 @@ describe('helm > chart > helpers > release', () => {
             owner: undefined,
             repo: undefined,
             branch: 'gh-pages',
+            commit: undefined,
             token: undefined,
             generateReleaseNotes: false,
         });
@@ -81,6 +83,7 @@ describe('helm > chart > helpers > release', () => {
             owner: 'tada5hi',
             repo: 'hevi',
             branch: 'pages',
+            commit: undefined,
             token: 'secret',
             generateReleaseNotes: false,
         });
@@ -94,6 +97,7 @@ describe('helm > chart > helpers > release', () => {
             owner: 'tada5hi',
             repo: 'hevi',
             branch: 'gh-pages',
+            commit: undefined,
             token: 'from-github-token',
             generateReleaseNotes: false,
         });
@@ -122,8 +126,21 @@ describe('helm > chart > helpers > release', () => {
             owner: 'other',
             repo: 'chart',
             branch: 'gh-pages',
+            commit: undefined,
             token: 'from-github-token',
             generateReleaseNotes: false,
         });
+    });
+
+    it('should default the commit to the github sha', () => {
+        process.env.GITHUB_SHA = 'abc123';
+
+        expect(normalizeHelmChartsReleaseOptions().commit).toEqual('abc123');
+    });
+
+    it('should not override an explicit commit', () => {
+        process.env.GITHUB_SHA = 'abc123';
+
+        expect(normalizeHelmChartsReleaseOptions({ commit: 'def456' }).commit).toEqual('def456');
     });
 });

--- a/test/unit/helm/chart/manager-commands.spec.ts
+++ b/test/unit/helm/chart/manager-commands.spec.ts
@@ -27,9 +27,15 @@ describe('helm > chart > manager > commands', () => {
     let helmBinary : FakeBinary;
     let helmChartReleaserBinary : FakeBinary;
     let manager : HelmChartManager;
+    let commitSha : string | undefined;
 
     beforeEach(async () => {
         cwd = process.cwd();
+
+        // the release args are asserted verbatim, and the workflow running these
+        // tests provides a GITHUB_SHA which would be picked up as --commit
+        commitSha = process.env.GITHUB_SHA;
+        delete process.env.GITHUB_SHA;
 
         directory = await fs.promises.realpath(
             await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hevi-test-')),
@@ -48,6 +54,12 @@ describe('helm > chart > manager > commands', () => {
 
     afterEach(async () => {
         process.chdir(cwd);
+
+        if (typeof commitSha === 'undefined') {
+            delete process.env.GITHUB_SHA;
+        } else {
+            process.env.GITHUB_SHA = commitSha;
+        }
 
         await fs.promises.rm(directory, { recursive: true, force: true });
     });
@@ -186,6 +198,36 @@ describe('helm > chart > manager > commands', () => {
         // `cr index` rejects the flag, so it must not leak into the shared args
         expect(index?.[0]).toEqual('index');
         expect(index).not.toContain('--generate-release-notes');
+    });
+
+    it('should pass the commit to upload but never to index', async () => {
+        await manager.releaseCharts({
+            owner: 'tada5hi',
+            repo: 'hevi',
+            commit: 'abc123',
+        });
+
+        const [upload, index] = helmChartReleaserBinary.calls;
+
+        // an empty target_commitish makes the GitHub release API answer 422
+        expect(upload?.[0]).toEqual('upload');
+        expect(upload).toContain('--commit');
+        expect(upload?.[upload.indexOf('--commit') + 1]).toEqual('abc123');
+
+        // `cr index` has no --commit flag, and its -c shorthand means --charts-repo
+        expect(index?.[0]).toEqual('index');
+        expect(index).not.toContain('--commit');
+    });
+
+    it('should default the release commit to the github sha', async () => {
+        process.env.GITHUB_SHA = 'from-env';
+
+        await manager.releaseCharts({ owner: 'tada5hi', repo: 'hevi' });
+
+        const [upload] = helmChartReleaserBinary.calls;
+
+        expect(upload).toContain('--commit');
+        expect(upload?.[upload.indexOf('--commit') + 1]).toEqual('from-env');
     });
 
     it('should push charts to an oci registry', async () => {


### PR DESCRIPTION
Fixes #60.

`cr upload` was invoked without `--commit`, so chart-releaser posted an empty
`target_commitish` and the GitHub API answered `422 Invalid target_commitish parameter`.
Creating a **new** chart release always failed; runs stayed green only as long as
`--skip-existing` skipped every already-released version, which is why this surfaced on the
first version bump after adopting hevi ([authup/helm run 30939094583](https://github.com/authup/helm/actions/runs/30939094583)).

## Changes

- `commit` option on `HelmChartsReleaseOptions`, `--commit` on `hevi release`, `release-commit`
  action input (defaults to `${{ github.sha }}`)
- `normalizeHelmChartsReleaseOptions()` falls back to `GITHUB_SHA`, matching the existing
  `owner`/`repo`/`token` env handling
- the flag is appended to the **upload-only** args: `cr index` has no `--commit`, and its `-c`
  shorthand means `--charts-repo`, so leaking it into the shared arg list would break indexing

## Verification

- `npx tsc --noEmit`, `npm run build`, `npm run lint` clean
- `npm run test`: 78 passed
- the two new manager tests fail with the `manager.ts` change reverted (checked via `git stash`)
- suite re-run with `GITHUB_SHA` set, since the release args are asserted verbatim and the
  workflow running the tests provides one; the specs now neutralize it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for targeting GitHub releases to a specific commit.
  - GitHub Actions now accepts an optional `release-commit` input, defaulting to the workflow commit.
  - The release CLI supports a `--commit` option, defaulting to `GITHUB_SHA`.

- **Documentation**
  - Updated CLI, GitHub Action, and environment variable documentation for commit targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->